### PR TITLE
Add Chrome-style tab closing effect

### DIFF
--- a/css/chrome-tabs.css
+++ b/css/chrome-tabs.css
@@ -27,6 +27,7 @@
   margin: 0;
   z-index: 1;
   pointer-events: none;
+  transition: width .2s, transform .2s;
 }
 .chrome-tabs .chrome-tab,
 .chrome-tabs .chrome-tab * {
@@ -104,6 +105,7 @@
 .chrome-tabs .chrome-tab.chrome-tab-was-just-added {
   top: 10px;
   animation: chrome-tab-was-just-added 120ms forwards ease-in-out;
+  transition: none;
 }
 .chrome-tabs .chrome-tab .chrome-tab-content {
   position: absolute;

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -44,6 +44,9 @@ export function useChromeTabs(listeners: Listeners) {
     const chromeTabs = new ChromeTabsClz();
     chromeTabsRef.current = chromeTabs;
     chromeTabs.init(ref.current as HTMLDivElement);
+    return () => {
+      chromeTabs.destroy();
+    }
   }, []);
 
   // activated


### PR DESCRIPTION
When Chrome tabs are closed continuously, the width will not be recalculated immediately, but will be recalculated when the mouse is moved away, making it easier to close continuously.