### PR TITLE
Fix: Prevent tabClick event when closing a tab

### DIFF
--- a/src/chrome-tabs.ts
+++ b/src/chrome-tabs.ts
@@ -347,7 +347,12 @@ class ChromeTabs {
     tabEl.oncontextmenu = (event) => {
       this.emit("contextmenu", { tabEl, event });
     };
-    tabEl.addEventListener("mousedown", () => {
+    tabEl.addEventListener("mousedown", (e) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest(".chrome-tab-close")) {
+        return;
+      }
       this.emit("tabClick", { tabEl });
     });
     if (animate) {


### PR DESCRIPTION
Hi!
First of all, thanks for your fork library. I’m using it in my project and it works great 👍

While integrating it, I noticed that when closing a tab, the tabClick event is still triggered, even though the user intent is to close the tab, not to activate it.

This PR prevents tabClick from being emitted when the close action is performed.

Thanks and feel free to let me know if you’d like this handled differently.